### PR TITLE
Update default fan speed configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Upon installation of the Argon ONE (V2) Pi 4 script by default, the settings of 
 
 CPU TEMP | FAN POWER
 :------: | :-------:
-55 C | 10%
+55 C | 30%
 60 C | 55%
 65 C | 100%
 


### PR DESCRIPTION
According to [script](https://github.com/okunze/Argon40-ArgonOne-Script/blob/6979175767a916df69309f002c2ce1f80829d2c1/source/argon1.sh#L282) and my fresh install the default value has been changed from 10% to 30%